### PR TITLE
Changes build to target netstandard

### DIFF
--- a/AppInsights.TelemetryInitializers/AppInsights.TelemetryInitializers.csproj
+++ b/AppInsights.TelemetryInitializers/AppInsights.TelemetryInitializers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.1.0</Version>
     <Authors>Vincent-Philippe Lauzon</Authors>


### PR DESCRIPTION
Sorry, this took me a bit longer than expected.  I considered trying to support older NET Framework versions but I decided it wasn't worth the trouble.

This should work all .NET Framework versions targeting 4.6.1+.

#1 